### PR TITLE
Create Unity transitioned from Collaborate to Plastic SCM.md

### DIFF
--- a/Unity transitioned from Collaborate to Plastic SCM.md
+++ b/Unity transitioned from Collaborate to Plastic SCM.md
@@ -1,0 +1,18 @@
+# Unity transitioned from Collaborate to Plastic SCM
+
+Before Unity transitioned from Collaborate to Plastic SCM, users reported several challenges with the Collaborate service:
+
+- **Reliability Issues**: Collaborate was described as "buggy," often failing in critical tasks, which hindered the game development process. citeturn0search9
+
+- **Migration Difficulties**: The process of migrating projects from Collaborate to Plastic SCM was complex, especially for users without prior experience with Plastic SCM. citeturn0search9
+
+- **Project Compatibility**: Some users experienced project breakages after transitioning to Plastic SCM, despite having no prior issues with Collaborate. citeturn0search2
+
+- **Incomplete Migrations**: There were instances where projects were not automatically migrated to Plastic SCM, leading to concerns about data loss and lack of prior notification. citeturn0search7
+
+These challenges highlighted the need for a more robust and user-friendly version control system, which led to the adoption of Plastic SCM.
+
+cite
+[turn0search9](https://forum.plasticscm.com/topic/23031-i-love-plastic-but-some-issues-novice-plastic-user-running-out-from-unity-collaborate-first-impression/?utm_source=chatgpt.com)
+[turn0search2](https://discussions.unity.com/t/plastic-scm-really-complicated/873029?utm_source=chatgpt.com)
+[turn0search7](https://discussions.unity.com/t/my-collab-projects-were-not-automatically-migrated-to-plastic-scm/903124?utm_source=chatgpt.com)


### PR DESCRIPTION
```markdown
# Unity transitioned from Collaborate to Plastic SCM

Before Unity transitioned from Collaborate to Plastic SCM, users reported several challenges with the Collaborate service:

- **Reliability Issues**: Collaborate was described as "buggy," often failing in critical tasks, which hindered the game development process. citeturn0search9

- **Migration Difficulties**: The process of migrating projects from Collaborate to Plastic SCM was complex, especially for users without prior experience with Plastic SCM. citeturn0search9

- **Project Compatibility**: Some users experienced project breakages after transitioning to Plastic SCM, despite having no prior issues with Collaborate. citeturn0search2

- **Incomplete Migrations**: There were instances where projects were not automatically migrated to Plastic SCM, leading to concerns about data loss and lack of prior notification. citeturn0search7

These challenges highlighted the need for a more robust and user-friendly version control system, which led to the adoption of Plastic SCM.

cite
[turn0search9](https://forum.plasticscm.com/topic/23031-i-love-plastic-but-some-issues-novice-plastic-user-running-out-from-unity-collaborate-first-impression/?utm_source=chatgpt.com)
[turn0search2](https://discussions.unity.com/t/plastic-scm-really-complicated/873029?utm_source=chatgpt.com)
[turn0search7](https://discussions.unity.com/t/my-collab-projects-were-not-automatically-migrated-to-plastic-scm/903124?utm_source=chatgpt.com)
```